### PR TITLE
Track deals on retailer wishlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 
 # Change Log
 
+## 0.1.6 (July 30, 2025)
+
+Notes: 
+* tbr-deal-finder now also tracks deals on the books in your wishlist. Works for all retailers.   
+
+BUG FIXES:
+* Fixed issue where no deals would display if libro is the only tracked audiobook retailer.
+* Fixed retailer cli setup forcing a user to select at least two audiobook retailers.
+
 ## 0.1.5 (July 30, 2025)
 
 Notes: 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Track price drops and find deals on books in your TBR (To Be Read) list across a
 
 ## Features
 - Uses your StoryGraph exports, Goodreads exports, and custom csvs (spreadsheet) to track book deals
-- Supports multiple of the library exports above 
+- Supports multiple of the library exports above
+- Tracks deals on the wishlist of all your configured retailers like audible 
 - Supports multiple locales and currencies
 - Finds the latest and active deals from supported sellers
 - Simple CLI interface for setup and usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tbr-deal-finder"
-version = "0.1.5"
+version = "0.1.6"
 description = "Track price drops and find deals on books in your TBR list across audiobook and ebook formats."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tbr_deal_finder/retailer/audible.py
+++ b/tbr_deal_finder/retailer/audible.py
@@ -75,6 +75,23 @@ class Audible(Retailer):
     def name(self) -> str:
         return "Audible"
 
+    @property
+    def format(self) -> BookFormat:
+        return BookFormat.AUDIOBOOK
+
+    async def set_auth(self):
+        if not os.path.exists(_AUTH_PATH):
+            auth = audible.Authenticator.from_login_external(
+                locale=Config.locale,
+                login_url_callback=login_url_callback
+            )
+
+            # Save credentials to file
+            auth.to_file(_AUTH_PATH)
+
+        self._auth = audible.Authenticator.from_file(_AUTH_PATH)
+        self._client = audible.AsyncClient(auth=self._auth)
+
     async def get_book(
         self,
         target: Book,
@@ -132,15 +149,5 @@ class Audible(Retailer):
                 exists=False,
             )
 
-    async def set_auth(self):
-        if not os.path.exists(_AUTH_PATH):
-            auth = audible.Authenticator.from_login_external(
-                locale=Config.locale,
-                login_url_callback=login_url_callback
-            )
-
-            # Save credentials to file
-            auth.to_file(_AUTH_PATH)
-
-        self._auth = audible.Authenticator.from_file(_AUTH_PATH)
-        self._client = audible.AsyncClient(auth=self._auth)
+    async def get_wishlist(self, config: Config) -> list[Book]:
+        ...

--- a/tbr_deal_finder/retailer/audible.py
+++ b/tbr_deal_finder/retailer/audible.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import os.path
 from datetime import datetime
 from textwrap import dedent
@@ -22,11 +23,9 @@ def login_url_callback(url: str) -> str:
 
     try:
         from playwright.sync_api import sync_playwright  # type: ignore
-        use_playwright = True
     except ImportError:
-        use_playwright = False
-
-    if use_playwright:
+        pass
+    else:
         with sync_playwright() as p:
             iphone = p.devices["iPhone 12 Pro"]
             browser = p.webkit.launch(headless=False)
@@ -112,19 +111,7 @@ class Audible(Retailer):
                 ]
             )
 
-            if not match["products"]:
-                return Book(
-                    retailer=self.name,
-                    title=title,
-                    authors=authors,
-                    list_price=0,
-                    current_price=0,
-                    timepoint=runtime,
-                    format=BookFormat.AUDIOBOOK,
-                    exists=False,
-                )
-
-            for product in match["products"]:
+            for product in match.get("products", []):
                 if product["title"] != title:
                     continue
 
@@ -150,4 +137,37 @@ class Audible(Retailer):
             )
 
     async def get_wishlist(self, config: Config) -> list[Book]:
-        ...
+        wishlist_books = []
+
+        page = 0
+        total_pages = 1
+        page_size = 50
+        while page < total_pages:
+            response = await self._client.get(
+                "1.0/wishlist",
+                num_results=page_size,
+                page=page,
+                response_groups=[
+                    "contributors, product_attrs, product_desc, product_extended_attrs"
+                ]
+            )
+
+            for audiobook in response.get("products", []):
+                authors = [author["name"] for author in audiobook["authors"]]
+                wishlist_books.append(
+                    Book(
+                        retailer=self.name,
+                        title=audiobook["title"],
+                        authors=", ".join(authors),
+                        list_price=1,
+                        current_price=1,
+                        timepoint=config.run_time,
+                        format=self.format,
+                        audiobook_isbn=audiobook["isbn"],
+                    )
+                )
+
+            page += 1
+            total_pages = math.ceil(int(response.get("total_results", 1))/page_size)
+
+        return wishlist_books

--- a/tbr_deal_finder/retailer/chirp.py
+++ b/tbr_deal_finder/retailer/chirp.py
@@ -1,17 +1,25 @@
 import asyncio
-from datetime import datetime
+import json
+import os
+from datetime import datetime, timedelta
 
 import aiohttp
+import click
 
+from tbr_deal_finder import TBR_DEALS_PATH
 from tbr_deal_finder.config import Config
 from tbr_deal_finder.retailer.models import Retailer
 from tbr_deal_finder.book import Book, BookFormat, get_normalized_authors
-from tbr_deal_finder.utils import currency_to_float
+from tbr_deal_finder.utils import currency_to_float, echo_err
 
 
 class Chirp(Retailer):
     # Static because url for other locales just redirects to .com
-    _url: str = "https://www.chirpbooks.com/api/graphql"
+    _url: str = "https://api.chirpbooks.com/api/graphql"
+    USER_AGENT = "ChirpBooks/5.13.9 (Android)"
+
+    def __init__(self):
+        self.auth_token = None
 
     @property
     def name(self) -> str:
@@ -21,8 +29,58 @@ class Chirp(Retailer):
     def format(self) -> BookFormat:
         return BookFormat.AUDIOBOOK
 
+    async def make_request(self, request_type: str, **kwargs) -> dict:
+        headers = kwargs.pop("headers", {})
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+        headers["User-Agent"] = self.USER_AGENT
+        if self.auth_token:
+            headers["authorization"] = f"Bearer {self.auth_token}"
+
+        async with aiohttp.ClientSession() as http_client:
+            response = await http_client.request(
+                request_type.upper(),
+                self._url,
+                headers=headers,
+                **kwargs
+            )
+            if response.ok:
+                return await response.json()
+            else:
+                return {}
+
     async def set_auth(self):
-        return
+        auth_path = TBR_DEALS_PATH.joinpath("chirp.json")
+        if os.path.exists(auth_path):
+            with open(auth_path, "r") as f:
+                auth_info = json.load(f)
+                if auth_info:
+                    token_created_at = datetime.fromtimestamp(auth_info["created_at"])
+                    max_token_age = datetime.now() - timedelta(days=5)
+                    if token_created_at > max_token_age:
+                        self.auth_token = auth_info["data"]["signIn"]["user"]["token"]
+                        return
+
+        response = await self.make_request(
+            "POST",
+            json={
+                "query": "mutation signIn($email: String!, $password: String!) { signIn(email: $email, password: $password) { user { id token webToken email } } }",
+                "variables": {
+                    "email": click.prompt("Chirp account email"),
+                    "password": click.prompt("Chirp Password", hide_input=True),
+                }
+            }
+        )
+        if not response:
+            echo_err("Chirp login failed, please try again.")
+            await self.set_auth()
+
+        # Set token for future requests during the current execution
+        self.auth_token = response["data"]["signIn"]["user"]["token"]
+
+        response["created_at"] = datetime.now().timestamp()
+        with open(auth_path, "w") as f:
+            json.dump(response, f)
 
     async def get_book(
         self, target: Book, runtime: datetime, semaphore: asyncio.Semaphore
@@ -59,9 +117,10 @@ class Chirp(Retailer):
                 if not book["currentProduct"]:
                     continue
 
+                normalized_authors = get_normalized_authors([author["name"] for author in book["allAuthors"]])
                 if (
                     book["displayTitle"] == title
-                    and get_normalized_authors(book["displayAuthors"]) == target.normalized_authors
+                    and any(author in normalized_authors for author in target.normalized_authors)
                 ):
                     return Book(
                         retailer=self.name,
@@ -85,47 +144,39 @@ class Chirp(Retailer):
             )
 
     async def get_wishlist(self, config: Config) -> list[Book]:
-        # TODO: This won't work without logging in user
-        # TODO: Add a config to track whether user wants to login to retailers that do not require login
-        #   Be sure they're aware they'll lose wishlist tracking and owned book tracking
-
         wishlist_books = []
         page = 1
 
-        async with aiohttp.ClientSession() as http_client:
-            while True:
-                http_response = await http_client.request(
-                    "POST",
-                    self._url,
-                    json={
-                        "query": "fragment audiobookFields on Audiobook{id averageRating coverUrl displayAuthors displayTitle ratingsCount url allAuthors{name slug url}} fragment productFields on Product{discountPrice id isFreeListing listingPrice purchaseUrl savingsPercent showListingPrice timeLeft bannerType} query FetchWishlistDealAudiobooks($page:Int,$pageSize:Int){currentUserWishlist{paginatedItems(filter:\"currently_promoted\",sort:\"promotion_end_date\",salability:current_or_future){totalCount objects(page:$page,pageSize:$pageSize){... on WishlistItem{id audiobook{...audiobookFields currentProduct{...productFields}}}}}}}",
-                        "variables": {"page": page, "pageSize": 15},
-                        "operationName": "FetchCurrentUserRelatedAudiobooks"
-                    }
-                )
-                response_body = await http_response.json()
-                audiobooks = response_body.get(
-                    "data", {}
-                ).get("currentUserWishlist", {}).get("paginatedItems", {}).get("objects", [])
+        while True:
+            response = await self.make_request(
+                "POST",
+                json={
+                    "query": "fragment audiobookFields on Audiobook{id averageRating coverUrl displayAuthors displayTitle ratingsCount url allAuthors{name slug url}} fragment productFields on Product{discountPrice id isFreeListing listingPrice purchaseUrl savingsPercent showListingPrice timeLeft bannerType} query FetchWishlistDealAudiobooks($page:Int,$pageSize:Int){currentUserWishlist{paginatedItems(filter:\"currently_promoted\",sort:\"promotion_end_date\",salability:current_or_future){totalCount objects(page:$page,pageSize:$pageSize){... on WishlistItem{id audiobook{...audiobookFields currentProduct{...productFields}}}}}}}",
+                    "variables": {"page": page, "pageSize": 15},
+                    "operationName": "FetchWishlistDealAudiobooks"
+                }
+            )
 
-                if not audiobooks:
-                    print("wut?")
-                    print(response_body)
-                    return wishlist_books
+            audiobooks = response.get(
+                "data", {}
+            ).get("currentUserWishlist", {}).get("paginatedItems", {}).get("objects", [])
 
-                for book in audiobooks:
-                    audiobook = book["audiobook"]
-                    authors = [author["name"] for author in audiobook["displayAuthors"]]
-                    wishlist_books.append(
-                        Book(
-                            retailer=self.name,
-                            title=audiobook["displayTitle"],
-                            authors=", ".join(authors),
-                            list_price=1,
-                            current_price=1,
-                            timepoint=config.run_time,
-                            format=self.format,
-                        )
+            if not audiobooks:
+                return wishlist_books
+
+            for book in audiobooks:
+                audiobook = book["audiobook"]
+                authors = [author["name"] for author in audiobook["allAuthors"]]
+                wishlist_books.append(
+                    Book(
+                        retailer=self.name,
+                        title=audiobook["displayTitle"],
+                        authors=", ".join(authors),
+                        list_price=1,
+                        current_price=1,
+                        timepoint=config.run_time,
+                        format=self.format,
                     )
+                )
 
-                page += 1
+            page += 1

--- a/tbr_deal_finder/retailer/models.py
+++ b/tbr_deal_finder/retailer/models.py
@@ -2,7 +2,8 @@ import abc
 import asyncio
 from datetime import datetime
 
-from tbr_deal_finder.book import Book
+from tbr_deal_finder.book import Book, BookFormat
+from tbr_deal_finder.config import Config
 
 
 class Retailer(abc.ABC):
@@ -10,6 +11,13 @@ class Retailer(abc.ABC):
 
     @property
     def name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def format(self) -> BookFormat:
+        raise NotImplementedError
+
+    async def set_auth(self):
         raise NotImplementedError
 
     async def get_book(
@@ -31,7 +39,7 @@ class Retailer(abc.ABC):
             """
         raise NotImplementedError
 
-    async def set_auth(self):
+    async def get_wishlist(self, config: Config) -> list[Book]:
         raise NotImplementedError
 
 

--- a/tbr_deal_finder/retailer/models.py
+++ b/tbr_deal_finder/retailer/models.py
@@ -15,6 +15,14 @@ class Retailer(abc.ABC):
 
     @property
     def format(self) -> BookFormat:
+        """The format of the books they sell.
+
+        For example,
+        Audible would be audiobooks
+        Kindle would be ebooks
+
+        :return:
+        """
         raise NotImplementedError
 
     async def set_auth(self):

--- a/tbr_deal_finder/tracked_books.py
+++ b/tbr_deal_finder/tracked_books.py
@@ -1,0 +1,120 @@
+import asyncio
+import csv
+
+from tqdm.asyncio import tqdm_asyncio
+
+from tbr_deal_finder.book import Book, BookFormat, get_title_id
+from tbr_deal_finder.retailer import Chirp, RETAILER_MAP
+from tbr_deal_finder.config import Config
+from tbr_deal_finder.library_exports import (
+    get_book_authors,
+    get_book_title,
+    is_tbr_book,
+    requires_audiobook_list_price_default
+)
+from tbr_deal_finder.retailer.models import Retailer
+from tbr_deal_finder.utils import currency_to_float
+
+
+def _library_export_tbr_books(config: Config, tbr_book_map: dict[str: Book]):
+    """Adds tbr books in the library export to the provided tbr_book_map
+
+    :param config:
+    :param tbr_book_map:
+    :return:
+    """
+    for library_export_path in config.library_export_paths:
+
+        with open(library_export_path, 'r', newline='', encoding='utf-8') as file:
+            # Use csv.DictReader to get dictionaries with column headers
+            for book_dict in csv.DictReader(file):
+                if not is_tbr_book(book_dict):
+                    continue
+
+                title = get_book_title(book_dict)
+                authors = get_book_authors(book_dict)
+
+                key = get_title_id(title, authors, BookFormat.NA)
+                if key in tbr_book_map and tbr_book_map[key].audiobook_isbn:
+                    continue
+
+                tbr_book_map[key] = Book(
+                    retailer="N/A",
+                    title=title,
+                    authors=authors,
+                    list_price=0,
+                    current_price=0,
+                    timepoint=config.run_time,
+                    format=BookFormat.NA,
+                    audiobook_isbn=book_dict.get("audiobook_isbn"),
+                    audiobook_list_price=currency_to_float(book_dict.get("audiobook_list_price") or 0),
+                )
+
+
+async def _apply_dynamic_audiobook_list_price(config: Config, tbr_book_map: dict[str: Book]):
+    target_books = [
+        book
+        for book in tbr_book_map.values()
+        if book.format == BookFormat.AUDIOBOOK
+    ]
+    if not target_books:
+        return
+
+    chirp = Chirp()
+    semaphore = asyncio.Semaphore(5)
+    books_with_pricing: list[Book] = await tqdm_asyncio.gather(
+        *[
+            chirp.get_book(book, config.run_time, semaphore)
+            for book in target_books
+        ],
+        desc=f"Getting list prices for Libro.FM wishlist"
+    )
+    for book in books_with_pricing:
+        tbr_book_map[book.title_id].audiobook_list_price = book.list_price
+
+
+async def _retailer_wishlist(config: Config, tbr_book_map: dict[str: Book]):
+    """Adds wishlist books in the library export to the provided tbr_book_map
+    Books added here has the format the retailer sells (e.g. Audiobook)
+    so deals are only checked for retailers with that type.
+
+    For example,
+    I as a user have Dune on my audible wishlist.
+    I want to see deals for it on Libro because it's an audiobook.
+    I don't want to see Kindle deals.
+
+    :param config:
+    :param tbr_book_map:
+    :return:
+    """
+    for retailer_str in config.tracked_retailers:
+        retailer: Retailer = RETAILER_MAP[retailer_str]()
+        await retailer.set_auth()
+
+        for book in (await retailer.get_wishlist(config)):
+            na_key = get_title_id(book.title, book.authors, BookFormat.NA)
+            if na_key in tbr_book_map:
+                continue
+
+            key = book.title_id
+            if key in tbr_book_map and tbr_book_map[key].audiobook_isbn:
+                continue
+
+            tbr_book_map[key] = book
+
+    if requires_audiobook_list_price_default(config):
+        await _apply_dynamic_audiobook_list_price(config, tbr_book_map)
+
+
+async def get_tbr_books(config: Config) -> list[Book]:
+    tbr_book_map: dict[str: Book] = {}
+
+    # Get TBRs specified in the user library (StoryGraph/GoodReads) export
+    _library_export_tbr_books(config, tbr_book_map)
+
+    # Pull wishlist from tracked retailers
+    await _retailer_wishlist(config, tbr_book_map)
+
+    return list(tbr_book_map.values())
+
+

--- a/uv.lock
+++ b/uv.lock
@@ -563,7 +563,7 @@ wheels = [
 
 [[package]]
 name = "tbr-deal-finder"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary of changes

Notes: 
* tbr-deal-finder now also tracks deals on the books in your wishlist. Works for all retailers.   

BUG FIXES:
* Fixed issue where no deals would display if libro is the only tracked audiobook retailer.
* Fixed retailer cli setup forcing a user to select at least two audiobook retailers.