### PR TITLE
Add the ability to ignore price tracking on books

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,18 @@
 
 ---
 
-## 0.3.10 (November XX, 2025)
+## 0.3.11 (December 03, 2025)
+
+Notes:
+* Add the ability to ignore price tracking on books
+
+BUG FIXES:
+* Fix issue where purchased books were still showing in the "all deals" page
+* Fix issue where retailer deals displayed in the "all deals" page after the retailer was removed from user settings
+
+---
+
+## 0.3.10 (November 05, 2025)
 
 Notes:
 * Add price filter on the "All Deals" page

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tbr-deal-finder"
-version = "0.3.9"
+version = "0.3.11"
 description = "Track price drops and find deals on books in your TBR list across audiobook and ebook formats."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tbr_deal_finder/__init__.py
+++ b/tbr_deal_finder/__init__.py
@@ -1,5 +1,5 @@
 from pathlib import Path
 
-__VERSION__ = "0.3.9"
+__VERSION__ = "0.3.11"
 
 QUERY_PATH = Path(__file__).parent.joinpath("queries")

--- a/tbr_deal_finder/book.py
+++ b/tbr_deal_finder/book.py
@@ -1,9 +1,10 @@
 import re
 from datetime import datetime
 from enum import Enum
-from typing import Union
+from typing import Union, Optional
 
 import click
+import duckdb
 from Levenshtein import ratio
 from unidecode import unidecode
 
@@ -35,6 +36,7 @@ class Book:
         deleted: bool = False,
         exists: bool = True,
         is_internal: bool = False,
+        disable_price_tracking: bool = False,
     ):
         self.retailer = retailer
         self.title = get_normalized_title(title)
@@ -52,6 +54,11 @@ class Book:
         #   However, only the user only has DCC on their Audible wishlist
         #   We don't want to show the Kindle deal for the ebook but we need it for Audible pricing
         self.is_internal = is_internal
+
+        # Flag that the book should not be tracked
+        # Example: I have The Lies of Locke Lamora in my TBR
+        #   However, I can get it at the library, so I don't want to see deals on it.
+        self.disable_price_tracking = disable_price_tracking
 
         self.list_price = list_price
         self.current_price = current_price
@@ -143,6 +150,7 @@ class Book:
             "audiobook_list_price": self.audiobook_list_price,
             "book_id": self.title_id,
             "is_internal": self.is_internal,
+            "disable_price_tracking": self.disable_price_tracking,
         }
 
     def unknown_book_dict(self):
@@ -155,8 +163,47 @@ class Book:
         }
 
 
+def update_price_tracking(
+    db_conn: duckdb.DuckDBPyConnection,
+    book: Book,
+):
+    db_conn.execute(
+        "UPDATE tbr_book SET disable_price_tracking = $dpt WHERE book_id = $id",
+        dict(dpt=book.disable_price_tracking, id=book.title_id),
+    )
+    if book.disable_price_tracking:
+        db_conn.execute(
+            "DELETE FROM retailer_deal WHERE title = $title AND authors=$authors",
+            dict(title=book.title, authors=book.authors),
+        )
+
+
+def prune_retailer_deal_table(
+    db_conn: duckdb.DuckDBPyConnection,
+    config: Optional[Config] = None
+):
+    db_conn.execute("""
+    DELETE FROM retailer_deal rd
+    WHERE NOT EXISTS (
+        SELECT 1 
+        FROM tbr_book b 
+        WHERE rd.title = b.title AND rd.authors = b.authors
+    )
+    """)
+
+    if config:
+        db_conn.execute(
+            """
+            DELETE FROM retailer_deal
+            WHERE retailer NOT IN $retailers
+            """,
+            dict(retailers=config.tracked_retailers)
+        )
+
+
 def get_deals_found_at(timepoint: datetime) -> list[Book]:
     db_conn = get_duckdb_conn()
+    prune_retailer_deal_table(db_conn)
     query_response = execute_query(
         db_conn,
         get_query_by_name("get_deals_found_at.sql"),
@@ -167,6 +214,7 @@ def get_deals_found_at(timepoint: datetime) -> list[Book]:
 
 def get_active_deals() -> list[Book]:
     db_conn = get_duckdb_conn()
+    prune_retailer_deal_table(db_conn)
     query_response = execute_query(
         db_conn,
         get_query_by_name("get_active_deals.sql")

--- a/tbr_deal_finder/cli.py
+++ b/tbr_deal_finder/cli.py
@@ -10,7 +10,7 @@ import questionary
 
 from tbr_deal_finder.config import Config
 from tbr_deal_finder.migrations import make_migrations
-from tbr_deal_finder.book import get_deals_found_at, print_books, get_active_deals
+from tbr_deal_finder.book import get_deals_found_at, print_books, get_active_deals, prune_retailer_deal_table
 from tbr_deal_finder.retailer import RETAILER_MAP
 from tbr_deal_finder.retailer_deal import get_latest_deals
 from tbr_deal_finder.tracked_books import reprocess_incomplete_tbr_books, clear_unknown_books
@@ -186,6 +186,10 @@ def _set_config() -> Config:
     )
 
     config.save()
+    db_conn = get_duckdb_conn()
+    prune_retailer_deal_table(db_conn, config)
+    db_conn.close()
+
     echo_success("Configuration saved!")
 
     return config

--- a/tbr_deal_finder/gui/pages/base_book_page.py
+++ b/tbr_deal_finder/gui/pages/base_book_page.py
@@ -4,7 +4,8 @@ import flet as ft
 from abc import ABC, abstractmethod
 from typing import List, Any
 
-from tbr_deal_finder.book import Book, BookFormat, get_normalized_authors
+from tbr_deal_finder.book import Book, BookFormat, get_normalized_authors, update_price_tracking
+from tbr_deal_finder.utils import get_duckdb_conn
 
 
 class BaseBookPage(ABC):
@@ -311,3 +312,45 @@ class BaseBookPage(ABC):
         
         # Reload data
         self.load_items()
+
+    def show_price_tracking_dialog(self, deal: Book):
+        """Show dialog to enable/disable price tracking for a deal"""
+        # Determine the message based on current state
+        if deal.disable_price_tracking:
+            message = f"Enable price tracking for {deal.title}?"
+        else:
+            message = f"Disable price tracking for {deal.title}?"
+
+        def on_yes(e):
+            # Toggle the disable_price_tracking flag
+            deal.disable_price_tracking = not deal.disable_price_tracking
+
+            # Update the database
+            db_conn = get_duckdb_conn()
+            update_price_tracking(db_conn, deal)
+
+            # Close the dialog
+            dialog.open = False
+            self.app.page.update()
+
+            # Reload items and refresh display
+            self.load_items()
+            self.update_items_display()
+
+        def on_cancel(e):
+            dialog.open = False
+            self.app.page.update()
+
+        dialog = ft.AlertDialog(
+            title=ft.Text("Price Tracking"),
+            content=ft.Text(message),
+            actions=[
+                ft.TextButton("Cancel", on_click=on_cancel),
+                ft.ElevatedButton("Yes", on_click=on_yes)
+            ],
+            modal=True
+        )
+
+        self.app.page.overlay.append(dialog)
+        dialog.open = True
+        self.app.page.update()

--- a/tbr_deal_finder/gui/pages/base_deals_page.py
+++ b/tbr_deal_finder/gui/pages/base_deals_page.py
@@ -28,9 +28,17 @@ class BaseDealsPage(BaseBookPage):
                             ft.Text(f"was {original_price}", color=ft.Colors.GREY_500, size=12)
                         ])
                     ], spacing=2),
-                    trailing=ft.Column([
-                        ft.Text(deal.retailer, weight=ft.FontWeight.BOLD, size=12)
-                    ], alignment=ft.MainAxisAlignment.CENTER),
+                    trailing=ft.Row([
+                        ft.IconButton(
+                            icon=ft.Icons.VISIBILITY,
+                            tooltip="Toggle price tracking",
+                            on_click=lambda e, book=deal: self.show_price_tracking_dialog(book),
+                            icon_size=20
+                        ),
+                        ft.Column([
+                            ft.Text(deal.retailer, weight=ft.FontWeight.BOLD, size=12)
+                        ], alignment=ft.MainAxisAlignment.CENTER)
+                    ], spacing=5, tight=True),
                     on_click=lambda e, book=deal: self.app.show_book_details(book, book.format)
                 ),
                 padding=10,

--- a/tbr_deal_finder/gui/pages/settings.py
+++ b/tbr_deal_finder/gui/pages/settings.py
@@ -2,9 +2,11 @@ from pathlib import Path
 
 import flet as ft
 
+from tbr_deal_finder.book import prune_retailer_deal_table
 from tbr_deal_finder.config import Config
 from tbr_deal_finder.retailer import RETAILER_MAP
 from tbr_deal_finder.tracked_books import reprocess_incomplete_tbr_books, clear_unknown_books
+from tbr_deal_finder.utils import get_duckdb_conn
 
 
 class SettingsPage:
@@ -356,7 +358,10 @@ class SettingsPage:
                 self.config.set_locale(self.locale)
 
             self.config.save()
-            
+            db_conn = get_duckdb_conn()
+            prune_retailer_deal_table(db_conn, self.config)
+            db_conn.close()
+
             # Reprocess books if retailers changed
             reprocess_incomplete_tbr_books(self.config)
             clear_unknown_books()

--- a/tbr_deal_finder/gui/pages/wishlist.py
+++ b/tbr_deal_finder/gui/pages/wishlist.py
@@ -89,6 +89,12 @@ class WishlistPage(BaseBookPage):
                     subtitle=ft.Column([
                         ft.Text(f"by {book.authors}", color=ft.Colors.GREY_600),
                     ], spacing=2),
+                    trailing=ft.IconButton(
+                        icon=ft.Icons.VISIBILITY if not book.disable_price_tracking else ft.Icons.VISIBILITY_OFF,
+                        tooltip="Toggle price tracking",
+                        on_click=lambda e, b=book: self.show_price_tracking_dialog(b),
+                        icon_size=20
+                    ),
                     on_click=lambda e, b=book: self.app.show_book_details(b, b.format)
                 ),
                 padding=10,

--- a/tbr_deal_finder/migrations.py
+++ b/tbr_deal_finder/migrations.py
@@ -102,6 +102,13 @@ _MIGRATIONS = [
             ALTER TABLE retailer_deal ADD COLUMN is_internal BOOLEAN DEFAULT FALSE;
             """
     ),
+    TableMigration(
+        version=3,
+        table_name="tbr_book",
+        sql="""
+            ALTER TABLE tbr_book ADD COLUMN disable_price_tracking BOOLEAN DEFAULT FALSE;
+            """
+    ),
 ]
 
 

--- a/tbr_deal_finder/retailer_deal.py
+++ b/tbr_deal_finder/retailer_deal.py
@@ -217,6 +217,7 @@ async def _get_latest_deals(config: Config):
     books: list[Book] = []
     unknown_books: list[Book] = []
     tbr_books = await get_tbr_books(config)
+    tbr_books = [b for b in tbr_books if not b.disable_price_tracking]
     ignore_books: list[Book] = get_unknown_books(config)
     ignored_deal_ids: set[str] = {book.deal_id for book in ignore_books}
 

--- a/uv.lock
+++ b/uv.lock
@@ -1190,7 +1190,7 @@ wheels = [
 
 [[package]]
 name = "tbr-deal-finder"
-version = "0.3.9"
+version = "0.3.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
Notes:
* Add the ability to ignore price tracking on books

BUG FIXES:
* Fix issue where purchased books were still showing in the "all deals" page
* Fix issue where retailer deals displayed in the "all deals" page after the retailer was removed from user settings