### PR TITLE
Add set_tracked_retailers to Config

### DIFF
--- a/tbr_deal_finder/config.py
+++ b/tbr_deal_finder/config.py
@@ -66,6 +66,9 @@ class Config:
 
             cls.locale = code
 
+    def set_tracked_retailers(self, retailers: Union[list, str, None]) -> None:
+        self.tracked_retailers = get_normalized_list(retailers)
+
     @classmethod
     def load(cls) -> "Config":
         """Load configuration from file or return defaults."""


### PR DESCRIPTION
fix "AttributeError: 'Config' object has no attribute 'set_tracked_retailers'" error in CLI